### PR TITLE
Make scaffold work with `go generate`

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,10 +3,11 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
+
 	"github.com/boourns/scaffold/ast"
 	"github.com/boourns/scaffold/model"
 	"github.com/boourns/scaffold/static"
-	"os"
 )
 
 var flags *flag.FlagSet

--- a/model/scaffold.go
+++ b/model/scaffold.go
@@ -33,6 +33,10 @@ func (c model) Generate(flags *flag.FlagSet) error {
 	}
 
 	if inFileName == "" {
+		inFileName = os.Getenv("GOFILE")
+	}
+
+	if inFileName == "" {
 		return printError("Missing input file.")
 	}
 

--- a/model/test/user.go
+++ b/model/test/user.go
@@ -1,5 +1,7 @@
 package user
 
+//go:generate scaffold model
+
 type User struct {
 	ID         int64
 	Name       string


### PR DESCRIPTION
On this branch you can run go generate to run scaffold on any model that has the `//go:generate scaffold model` comment. Scaffold has to be on your path. Easy way to do that is to run `go build`, `go install` and then `go generate ./...`.

The only change needed to make this work was the to check the $GOFILE environment variable for the file name when you don't get one from the command line.

Command line usage should be unchanged.