### PR TITLE
Use module path to gen with go run, avoid build install

### DIFF
--- a/model/test/user.go
+++ b/model/test/user.go
@@ -1,6 +1,6 @@
 package user
 
-//go:generate scaffold model
+//go:generate go run github.com/boourns/scaffold model
 
 type User struct {
 	ID         int64


### PR DESCRIPTION
Fixed in module generation to use `go run` avoiding build and install steps. Just edit code and run `go generate ./...`.