### PR TITLE
ast.Field split override on space, not comma

### DIFF
--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -26,7 +26,7 @@ func TestAstOverrides(t *testing.T) {
 	field := model.Fields[1]
 	field.parseOverrides()
 
-	if str := field.Override("field", "wrong default"); str != "yolo" {
+	if str := field.Override("field", "wrong default"); str != "\"yolo\"" {
 		t.Errorf("Overrides loading failed, returned %s overrides %#v", str, field.overrides)
 	}
 }

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -1,12 +1,14 @@
 package ast
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestAstModelParses(t *testing.T) {
 	model := Parse("test/model.go")
 
-	if len(model.Fields) != 2 {
-		t.Errorf("Expected 2 fields")
+	if len(model.Fields) != 3 {
+		t.Errorf("Expected 3 fields")
 	}
 
 	if model.Package != "user" {
@@ -21,12 +23,23 @@ func TestAstModelParses(t *testing.T) {
 func TestAstOverrides(t *testing.T) {
 	model := Parse("test/model.go")
 
-	model.parseOverrides()
-
 	field := model.Fields[1]
 	field.parseOverrides()
 
 	if str := field.Override("field", "wrong default"); str != "yolo" {
+		t.Errorf("Overrides loading failed, returned %s overrides %#v", str, field.overrides)
+	}
+}
+
+func TestAstOverridesJsonAndSqlType(t *testing.T) {
+	model := Parse("test/model.go")
+	field := model.Fields[2]
+	field.parseOverrides()
+
+	if str := field.Override("json", "wrong default"); str != "\"updatedAt\"" {
+		t.Errorf("Overrides loading failed, returned %s overrides %#v", str, field.overrides)
+	}
+	if str := field.Override("sqlType", "wrong default"); str != "\"DATETIME\"" {
 		t.Errorf("Overrides loading failed, returned %s overrides %#v", str, field.overrides)
 	}
 }

--- a/ast/field.go
+++ b/ast/field.go
@@ -24,7 +24,7 @@ func (f *Field) Override(key string, def string) string {
 func (f *Field) parseOverrides() {
 	f.overridesParsed = true
 	f.overrides = make(map[string]string)
-	fields := strings.Split(f.Tag, ",")
+	fields := strings.Split(f.Tag, " ")
 
 	for _, field := range fields {
 		if field == "" {

--- a/ast/test/model.go
+++ b/ast/test/model.go
@@ -4,7 +4,7 @@ import "time"
 
 type User struct {
 	Name      string
-	Admin     bool      `field:yolo`
+	Admin     bool      `field:"yolo"`
 	UpdatedAt time.Time `json:"updatedAt" sqlType:"DATETIME"`
 }
 

--- a/ast/test/model.go
+++ b/ast/test/model.go
@@ -1,8 +1,11 @@
 package user
 
+import "time"
+
 type User struct {
-	Name  string
-	Admin bool `field: yolo`
+	Name      string
+	Admin     bool      `field:yolo`
+	UpdatedAt time.Time `json:"updatedAt" sqlType:"DATETIME"`
 }
 
 func Yolo() {


### PR DESCRIPTION
Resolves #12.

ast.Field is doing a Split on comma when it should be space.

I have questions. Comments in line. 