### PR TITLE
Revert "Use camelCase naming scheme for TS models"

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -76,14 +76,6 @@ func (m *Model) FieldSlice() []string {
 	return out
 }
 
-func (m *Model) FieldSliceInCamelCase() []string {
-	out := []string{}
-	for _, v := range m.Fields {
-		out = append(out, v.NameInCamelCase())
-	}
-	return out
-}
-
 func (m *Model) FieldSliceWithoutID() []string {
 	out := []string{}
 	for _, v := range m.Fields {

--- a/ast/field.go
+++ b/ast/field.go
@@ -1,10 +1,6 @@
 package ast
 
-import (
-	"strings"
-
-	"github.com/iancoleman/strcase"
-)
+import "strings"
 
 type Field struct {
 	Name            string
@@ -43,8 +39,4 @@ func (f *Field) parseOverrides() {
 		f.overrides[key] = value
 	}
 
-}
-
-func (f *Field) NameInCamelCase() string {
-	return strcase.ToLowerCamel(f.Name)
 }

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,4 @@ require (
 	github.com/benbjohnson/ego v0.4.3
 	github.com/boourns/dblib v0.0.0-20211206181331-595b699a5ede
 	github.com/mattn/go-sqlite3 v1.14.9
-	github.com/iancoleman/strcase v0.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,5 @@ github.com/benbjohnson/ego v0.4.3 h1:9uO96riax3fhvRBpbUK5cZvZ14u9U4ZcGgrANwppFqs
 github.com/benbjohnson/ego v0.4.3/go.mod h1:Sa5eTS6AJJy62BL2Y4ba70gt0ZayBXw2R5yZUD1ves8=
 github.com/boourns/dblib v0.0.0-20211206181331-595b699a5ede h1:vMNJP2x/uXI78kb5a9UC6eQLi6fteBLQLmE2bLpmzA0=
 github.com/boourns/dblib v0.0.0-20211206181331-595b699a5ede/go.mod h1:5DIzBnupyRy4Nwpd7i5UIgQJ9MUERVr/jDnhl+x0GYA=
-github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
-github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/mattn/go-sqlite3 v1.14.9 h1:10HX2Td0ocZpYEjhilsuo6WWtUqttj2Kb0KtD86/KYA=
 github.com/mattn/go-sqlite3 v1.14.9/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=

--- a/model/model.ts.ego
+++ b/model/model.ts.ego
@@ -38,17 +38,17 @@ func tsTypeForSQLType(f ast.Field) string {
 }
 
 func fieldNameString(m * ast.Model) string {
-    return strings.Join(m.FieldSliceInCamelCase(), ",")
+    return strings.Join(m.FieldSlice(), ",")
 }
 
 func modelTemplateTS(w io.Writer, m *ast.Model) {
 %>
 class <%== m.Name %> {
     <% for _, field := range m.Fields { %>
-    <%== field.NameInCamelCase() %>: <%== tsTypeForField(field) %> | undefined
+    <%== field.Name %>: <%== tsTypeForField(field) %> | undefined
     <%}%>
-    selectAll: string = "SELECT <%==fieldNameString(m)%> FROM <%== m.Name %>"
-    selectByID: string = "SELECT <%==fieldNameString(m)%> FROM <%== m.Name %> WHERE ID=?"
+    SelectAll: string = "SELECT <%==fieldNameString(m)%> FROM <%== m.Name %>"
+    SelectByID: string = "SELECT <%==fieldNameString(m)%> FROM <%== m.Name %> WHERE ID=?"
 }
 export default <%== m.Name %>
 <%}%> 

--- a/model/model.ts.ego.go
+++ b/model/model.ts.ego.go
@@ -47,7 +47,7 @@ func tsTypeForSQLType(f ast.Field) string {
 }
 
 func fieldNameString(m *ast.Model) string {
-	return strings.Join(m.FieldSliceInCamelCase(), ",")
+	return strings.Join(m.FieldSlice(), ",")
 }
 
 func modelTemplateTS(w io.Writer, m *ast.Model) {
@@ -63,7 +63,7 @@ func modelTemplateTS(w io.Writer, m *ast.Model) {
 //line model.ts.ego:48
 		_, _ = io.WriteString(w, "\n    ")
 //line model.ts.ego:48
-		_, _ = fmt.Fprint(w, field.NameInCamelCase())
+		_, _ = fmt.Fprint(w, field.Name)
 //line model.ts.ego:48
 		_, _ = io.WriteString(w, ": ")
 //line model.ts.ego:48
@@ -73,7 +73,7 @@ func modelTemplateTS(w io.Writer, m *ast.Model) {
 //line model.ts.ego:49
 	}
 //line model.ts.ego:50
-	_, _ = io.WriteString(w, "\n    selectAll: string = \"SELECT ")
+	_, _ = io.WriteString(w, "\n    SelectAll: string = \"SELECT ")
 //line model.ts.ego:50
 	_, _ = fmt.Fprint(w, fieldNameString(m))
 //line model.ts.ego:50
@@ -81,7 +81,7 @@ func modelTemplateTS(w io.Writer, m *ast.Model) {
 //line model.ts.ego:50
 	_, _ = fmt.Fprint(w, m.Name)
 //line model.ts.ego:50
-	_, _ = io.WriteString(w, "\"\n    selectByID: string = \"SELECT ")
+	_, _ = io.WriteString(w, "\"\n    SelectByID: string = \"SELECT ")
 //line model.ts.ego:51
 	_, _ = fmt.Fprint(w, fieldNameString(m))
 //line model.ts.ego:51


### PR DESCRIPTION
This reverts the change added in #15 where camelCasing is done, since that causes issues—the model expects `camelCase` but the DB still returns `TitleCase`