### PR TITLE
Generate column descriptions for building SQL with TypeScript models

### DIFF
--- a/ast/field.go
+++ b/ast/field.go
@@ -1,6 +1,10 @@
 package ast
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/iancoleman/strcase"
+)
 
 type Field struct {
 	Name            string
@@ -39,4 +43,8 @@ func (f *Field) parseOverrides() {
 		f.overrides[key] = value
 	}
 
+}
+
+func (f *Field) NameInCamelCase() string {
+	return strcase.ToLowerCamel(f.Name)
 }

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/benbjohnson/ego v0.4.3
 	github.com/boourns/dblib v0.0.0-20211206181331-595b699a5ede
 	github.com/mattn/go-sqlite3 v1.14.9
+	github.com/iancoleman/strcase v0.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,7 @@ github.com/benbjohnson/ego v0.4.3 h1:9uO96riax3fhvRBpbUK5cZvZ14u9U4ZcGgrANwppFqs
 github.com/benbjohnson/ego v0.4.3/go.mod h1:Sa5eTS6AJJy62BL2Y4ba70gt0ZayBXw2R5yZUD1ves8=
 github.com/boourns/dblib v0.0.0-20211206181331-595b699a5ede h1:vMNJP2x/uXI78kb5a9UC6eQLi6fteBLQLmE2bLpmzA0=
 github.com/boourns/dblib v0.0.0-20211206181331-595b699a5ede/go.mod h1:5DIzBnupyRy4Nwpd7i5UIgQJ9MUERVr/jDnhl+x0GYA=
+github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
+github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/mattn/go-sqlite3 v1.14.9 h1:10HX2Td0ocZpYEjhilsuo6WWtUqttj2Kb0KtD86/KYA=
 github.com/mattn/go-sqlite3 v1.14.9/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=

--- a/model/model.ts.ego
+++ b/model/model.ts.ego
@@ -57,7 +57,7 @@ func modelTemplateTS(w io.Writer, m *ast.Model) {
 %>
 class <%== m.Name %> {
   <% for _, field := range m.Fields { %>
-  <%== field.Name %>: <%== tsTypeForField(field) %> | undefined
+  <%== field.Name %>?: <%== tsTypeForField(field) %>
   <%}%>
   static columns = { <%==fieldsAsColumnDescriptions(m)%> }
   static SelectAll: string = `SELECT <%==fieldsByColumnDescriptions(m)%> FROM <%== m.Name %>`

--- a/model/model.ts.ego
+++ b/model/model.ts.ego
@@ -37,18 +37,31 @@ func tsTypeForSQLType(f ast.Field) string {
     }
 }
 
-func fieldNameString(m * ast.Model) string {
-    return strings.Join(m.FieldSlice(), ",")
+func fieldsAsColumnDescriptions(m * ast.Model) string {
+    columns := []string{}
+    for _, f := range m.Fields {
+        columns = append(columns, fmt.Sprintf("%s: \"%s.%s\"", f.NameInCamelCase(), m.Name, f.Name))
+    }
+    return strings.Join(columns, ", ")
+}
+
+func fieldsByColumnDescriptions(m * ast.Model) string {
+    columns := []string{}
+    for _, f := range m.Fields {
+        columns = append(columns, fmt.Sprintf("${%s.columns.%s}", m.Name, f.NameInCamelCase()))
+    }
+    return strings.Join(columns, ", ")
 }
 
 func modelTemplateTS(w io.Writer, m *ast.Model) {
 %>
 class <%== m.Name %> {
-    <% for _, field := range m.Fields { %>
-    <%== field.Name %>: <%== tsTypeForField(field) %> | undefined
-    <%}%>
-    static SelectAll: string = "SELECT <%==fieldNameString(m)%> FROM <%== m.Name %>"
-    static SelectByID: string = "SELECT <%==fieldNameString(m)%> FROM <%== m.Name %> WHERE ID=?"
+  <% for _, field := range m.Fields { %>
+  <%== field.Name %>: <%== tsTypeForField(field) %> | undefined
+  <%}%>
+  static columns = { <%==fieldsAsColumnDescriptions(m)%> }
+  static SelectAll: string = `SELECT <%==fieldsByColumnDescriptions(m)%> FROM <%== m.Name %>`
+  static SelectByID: string = `SELECT <%==fieldsByColumnDescriptions(m)%> FROM <%== m.Name %> WHERE ID=?`
 }
 export default <%== m.Name %>
 <%}%> 

--- a/model/model.ts.ego.go
+++ b/model/model.ts.ego.go
@@ -46,55 +46,71 @@ func tsTypeForSQLType(f ast.Field) string {
 	}
 }
 
-func fieldNameString(m *ast.Model) string {
-	return strings.Join(m.FieldSlice(), ",")
+func fieldsAsColumnDescriptions(m *ast.Model) string {
+	columns := []string{}
+	for _, f := range m.Fields {
+		columns = append(columns, fmt.Sprintf("%s: \"%s.%s\"", f.NameInCamelCase(), m.Name, f.Name))
+	}
+	return strings.Join(columns, ", ")
+}
+
+func fieldsByColumnDescriptions(m *ast.Model) string {
+	columns := []string{}
+	for _, f := range m.Fields {
+		columns = append(columns, fmt.Sprintf("${%s.columns.%s}", m.Name, f.NameInCamelCase()))
+	}
+	return strings.Join(columns, ", ")
 }
 
 func modelTemplateTS(w io.Writer, m *ast.Model) {
 
-//line model.ts.ego:46
+//line model.ts.ego:58
 	_, _ = io.WriteString(w, "\nclass ")
-//line model.ts.ego:46
+//line model.ts.ego:58
 	_, _ = fmt.Fprint(w, m.Name)
-//line model.ts.ego:46
-	_, _ = io.WriteString(w, " {\n    ")
-//line model.ts.ego:47
+//line model.ts.ego:58
+	_, _ = io.WriteString(w, " {\n  ")
+//line model.ts.ego:59
 	for _, field := range m.Fields {
-//line model.ts.ego:48
-		_, _ = io.WriteString(w, "\n    ")
-//line model.ts.ego:48
+//line model.ts.ego:60
+		_, _ = io.WriteString(w, "\n  ")
+//line model.ts.ego:60
 		_, _ = fmt.Fprint(w, field.Name)
-//line model.ts.ego:48
+//line model.ts.ego:60
 		_, _ = io.WriteString(w, ": ")
-//line model.ts.ego:48
+//line model.ts.ego:60
 		_, _ = fmt.Fprint(w, tsTypeForField(field))
-//line model.ts.ego:48
-		_, _ = io.WriteString(w, " | undefined\n    ")
-//line model.ts.ego:49
+//line model.ts.ego:60
+		_, _ = io.WriteString(w, " | undefined\n  ")
+//line model.ts.ego:61
 	}
-//line model.ts.ego:50
-	_, _ = io.WriteString(w, "\n    static SelectAll: string = \"SELECT ")
-//line model.ts.ego:50
-	_, _ = fmt.Fprint(w, fieldNameString(m))
-//line model.ts.ego:50
+//line model.ts.ego:62
+	_, _ = io.WriteString(w, "\n  static columns = { ")
+//line model.ts.ego:62
+	_, _ = fmt.Fprint(w, fieldsAsColumnDescriptions(m))
+//line model.ts.ego:62
+	_, _ = io.WriteString(w, " }\n  static SelectAll: string = `SELECT ")
+//line model.ts.ego:63
+	_, _ = fmt.Fprint(w, fieldsByColumnDescriptions(m))
+//line model.ts.ego:63
 	_, _ = io.WriteString(w, " FROM ")
-//line model.ts.ego:50
+//line model.ts.ego:63
 	_, _ = fmt.Fprint(w, m.Name)
-//line model.ts.ego:50
-	_, _ = io.WriteString(w, "\"\n    static SelectByID: string = \"SELECT ")
-//line model.ts.ego:51
-	_, _ = fmt.Fprint(w, fieldNameString(m))
-//line model.ts.ego:51
+//line model.ts.ego:63
+	_, _ = io.WriteString(w, "`\n  static SelectByID: string = `SELECT ")
+//line model.ts.ego:64
+	_, _ = fmt.Fprint(w, fieldsByColumnDescriptions(m))
+//line model.ts.ego:64
 	_, _ = io.WriteString(w, " FROM ")
-//line model.ts.ego:51
+//line model.ts.ego:64
 	_, _ = fmt.Fprint(w, m.Name)
-//line model.ts.ego:51
-	_, _ = io.WriteString(w, " WHERE ID=?\"\n}\nexport default ")
-//line model.ts.ego:53
+//line model.ts.ego:64
+	_, _ = io.WriteString(w, " WHERE ID=?`\n}\nexport default ")
+//line model.ts.ego:66
 	_, _ = fmt.Fprint(w, m.Name)
-//line model.ts.ego:54
+//line model.ts.ego:67
 	_, _ = io.WriteString(w, "\n")
-//line model.ts.ego:54
+//line model.ts.ego:67
 }
 
 var _ fmt.Stringer

--- a/model/model.ts.ego.go
+++ b/model/model.ts.ego.go
@@ -77,11 +77,11 @@ func modelTemplateTS(w io.Writer, m *ast.Model) {
 //line model.ts.ego:60
 		_, _ = fmt.Fprint(w, field.Name)
 //line model.ts.ego:60
-		_, _ = io.WriteString(w, ": ")
+		_, _ = io.WriteString(w, "?: ")
 //line model.ts.ego:60
 		_, _ = fmt.Fprint(w, tsTypeForField(field))
-//line model.ts.ego:60
-		_, _ = io.WriteString(w, " | undefined\n  ")
+//line model.ts.ego:61
+		_, _ = io.WriteString(w, "\n  ")
 //line model.ts.ego:61
 	}
 //line model.ts.ego:62


### PR DESCRIPTION
This generates models in the shape of:
```ts

class User {
  
  ID: number | undefined
  
  Name: string | undefined
  
  Email: string | undefined
  
  ResetToken: string | undefined
  
  CreatedAt: Date | undefined
  
  static columns = { id: "User.ID", name: "User.Name", email: "User.Email", resetToken: "User.ResetToken", createdAt: "User.CreatedAt" }
  static SelectAll: string = `SELECT ${User.columns.id}, ${User.columns.name}, ${User.columns.email}, ${User.columns.resetToken}, ${User.columns.createdAt} FROM User`
  static SelectByID: string = `SELECT ${User.columns.id}, ${User.columns.name}, ${User.columns.email}, ${User.columns.resetToken}, ${User.columns.createdAt} FROM User WHERE ID=?`
}
export default User
```

It means that TS usage of scaffold can autocomplete `<Model>.columns.<fieldInCamel>` instead of hardcoding a string.

This is also return of the `strcase`.