### PR TITLE
Remove unneeded fmt.Sprintf

### DIFF
--- a/model/model.ego
+++ b/model/model.ego
@@ -21,13 +21,13 @@ import (
 )
 
 func sqlFieldsFor<%== m.Name %>() string {
-  return "<%== fieldString(fmt.Sprintf("%s.", m.Name), m.FieldSlice(), "") %>" // ADD FIELD HERE
+  return "<%== fieldString(fmt.Sprintf("%s.", m.Name), m.FieldSlice(), "") %>"
 }
 
 func load<%== m.Name %>(rows *sql.Rows) (*<%== m.Name %>, error) {
 	ret := <%== m.Name %>{}
 
-	err := rows.Scan(<%== fieldString("&ret.", m.FieldSlice(), "") %>) // ADD FIELD HERE
+	err := rows.Scan(<%== fieldString("&ret.", m.FieldSlice(), "") %>)
 	if err != nil {
 		return nil, err
 	}
@@ -53,13 +53,13 @@ func Select<%== m.Name %>(tx dblib.DBLike, cond string, condFields ...interface{
 }
 
 func (s *<%== m.Name %>) Update(tx dblib.DBLike) error {
-		stmt, err := tx.Prepare(fmt.Sprintf("UPDATE <%== m.Name %> SET <%== fieldString("", m.FieldSlice(), "=?") %> WHERE <%== m.Name %>.ID = ?", )) // ADD FIELD HERE
+		stmt, err := tx.Prepare("UPDATE <%== m.Name %> SET <%== fieldString("", m.FieldSlice(), "=?") %> WHERE <%== m.Name %>.ID = ?", )
 
 		if err != nil {
 			return err
 		}
 
-    params := []interface{}{<%== fieldString("s.", m.FieldSlice(), "") %>} // ADD FIELD HERE
+    params := []interface{}{<%== fieldString("s.", m.FieldSlice(), "") %>}
     params = append(params, s.ID)
 
 		_, err = stmt.Exec(params...)
@@ -71,12 +71,12 @@ func (s *<%== m.Name %>) Update(tx dblib.DBLike) error {
 }
 
 func (s *<%== m.Name %>) Insert(tx dblib.DBLike) error {
-		stmt, err := tx.Prepare("INSERT INTO <%== m.Name %>(<%== fieldString("", m.FieldSliceWithoutID(), "") %>) VALUES(<%== util.QuestionMarks(len(m.FieldSliceWithoutID())) %>)") // ADD FIELD HERE
+		stmt, err := tx.Prepare("INSERT INTO <%== m.Name %>(<%== fieldString("", m.FieldSliceWithoutID(), "") %>) VALUES(<%== util.QuestionMarks(len(m.FieldSliceWithoutID())) %>)")
 		if err != nil {
 			return err
 		}
 
-		result, err := stmt.Exec(<%== fieldString("s.", m.FieldSliceWithoutID(), "") %>) // ADD FIELD HERE
+		result, err := stmt.Exec(<%== fieldString("s.", m.FieldSliceWithoutID(), "") %>)
 		if err != nil {
 			return err
     }

--- a/model/model.ego.go
+++ b/model/model.ego.go
@@ -32,7 +32,7 @@ func modelTemplateGo(w io.Writer, m *ast.Model) {
 //line model.ego:24
 	_, _ = fmt.Fprint(w, fieldString(fmt.Sprintf("%s.", m.Name), m.FieldSlice(), ""))
 //line model.ego:24
-	_, _ = io.WriteString(w, "\" // ADD FIELD HERE\n}\n\nfunc load")
+	_, _ = io.WriteString(w, "\"\n}\n\nfunc load")
 //line model.ego:27
 	_, _ = fmt.Fprint(w, m.Name)
 //line model.ego:27
@@ -48,7 +48,7 @@ func modelTemplateGo(w io.Writer, m *ast.Model) {
 //line model.ego:30
 	_, _ = fmt.Fprint(w, fieldString("&ret.", m.FieldSlice(), ""))
 //line model.ego:30
-	_, _ = io.WriteString(w, ") // ADD FIELD HERE\n\tif err != nil {\n\t\treturn nil, err\n\t}\n\treturn &ret, nil\n}\n\nfunc Select")
+	_, _ = io.WriteString(w, ")\n\tif err != nil {\n\t\treturn nil, err\n\t}\n\treturn &ret, nil\n}\n\nfunc Select")
 //line model.ego:37
 	_, _ = fmt.Fprint(w, m.Name)
 //line model.ego:37
@@ -76,7 +76,7 @@ func modelTemplateGo(w io.Writer, m *ast.Model) {
 //line model.ego:55
 	_, _ = fmt.Fprint(w, m.Name)
 //line model.ego:55
-	_, _ = io.WriteString(w, ") Update(tx dblib.DBLike) error {\n\t\tstmt, err := tx.Prepare(fmt.Sprintf(\"UPDATE ")
+	_, _ = io.WriteString(w, ") Update(tx dblib.DBLike) error {\n\t\tstmt, err := tx.Prepare(\"UPDATE ")
 //line model.ego:56
 	_, _ = fmt.Fprint(w, m.Name)
 //line model.ego:56
@@ -88,11 +88,11 @@ func modelTemplateGo(w io.Writer, m *ast.Model) {
 //line model.ego:56
 	_, _ = fmt.Fprint(w, m.Name)
 //line model.ego:56
-	_, _ = io.WriteString(w, ".ID = ?\", )) // ADD FIELD HERE\n\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\n    params := []interface{}{")
+	_, _ = io.WriteString(w, ".ID = ?\", )\n\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\n    params := []interface{}{")
 //line model.ego:62
 	_, _ = fmt.Fprint(w, fieldString("s.", m.FieldSlice(), ""))
 //line model.ego:62
-	_, _ = io.WriteString(w, "} // ADD FIELD HERE\n    params = append(params, s.ID)\n\n\t\t_, err = stmt.Exec(params...)\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\n    return nil\n}\n\nfunc (s *")
+	_, _ = io.WriteString(w, "}\n    params = append(params, s.ID)\n\n\t\t_, err = stmt.Exec(params...)\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\n    return nil\n}\n\nfunc (s *")
 //line model.ego:73
 	_, _ = fmt.Fprint(w, m.Name)
 //line model.ego:73
@@ -108,11 +108,11 @@ func modelTemplateGo(w io.Writer, m *ast.Model) {
 //line model.ego:74
 	_, _ = fmt.Fprint(w, util.QuestionMarks(len(m.FieldSliceWithoutID())))
 //line model.ego:74
-	_, _ = io.WriteString(w, ")\") // ADD FIELD HERE\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\n\t\tresult, err := stmt.Exec(")
+	_, _ = io.WriteString(w, ")\")\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\n\t\tresult, err := stmt.Exec(")
 //line model.ego:79
 	_, _ = fmt.Fprint(w, fieldString("s.", m.FieldSliceWithoutID(), ""))
 //line model.ego:79
-	_, _ = io.WriteString(w, ") // ADD FIELD HERE\n\t\tif err != nil {\n\t\t\treturn err\n    }\n\n    s.ID, err = result.LastInsertId()\n    if err != nil {\n      return err\n    }\n\t  return nil\n}\n\nfunc (s *")
+	_, _ = io.WriteString(w, ")\n\t\tif err != nil {\n\t\t\treturn err\n    }\n\n    s.ID, err = result.LastInsertId()\n    if err != nil {\n      return err\n    }\n\t  return nil\n}\n\nfunc (s *")
 //line model.ego:91
 	_, _ = fmt.Fprint(w, m.Name)
 //line model.ego:91

--- a/model/model.ts.ego.go
+++ b/model/model.ts.ego.go
@@ -18,7 +18,7 @@ import (
 	//"fmt"
 )
 
-//arrays and slices aren't handled properly.
+// arrays and slices aren't handled properly.
 func tsTypeForField(f ast.Field) string {
 	switch f.Type {
 	case "int", "int8", "int16", "int32", "int64", "uint", "uint8", "uint16", "uint32", "uint64", "uintptr", "byte", "rune", "float32", "float64":


### PR DESCRIPTION
fmt.Sprintf on update calls never passes any arguments. The "format" string can be used directly.